### PR TITLE
Remove engineering data and fix track gaps

### DIFF
--- a/tess_asteroid_ml/asteroid_tess_ccut.py
+++ b/tess_asteroid_ml/asteroid_tess_ccut.py
@@ -271,11 +271,15 @@ class AsteroidTESScut:
         if hasattr(self, "asteroid_names"):
             if mask_num_type == "byte":
                 asteroid_number = 2 ** (len(self.asteroid_names))
+            elif mask_num_type == "index" and isinstance(name, pd.Series):
+                asteroid_number = name.name
             else:
                 asteroid_number = (len(self.asteroid_names)) + 1
         else:
             if mask_num_type == "byte":
                 asteroid_number = 2**0
+            elif mask_num_type == "index" and isinstance(name, pd.Series):
+                asteroid_number = name.name
             else:
                 asteroid_number = 1
             # self.asteroid_mask = np.zeros_like(self.flux, dtype=int)


### PR DESCRIPTION
This PR changes the following:

- Removes engineering data (CBVs, Quat, and angles) 
- Fixes the low-res tracks that produced segmented tracks in the mask array
- Adds a lightweight version of the track files when loading to save memory
- Adds an array (N_cuts, N_times) to the NPZ files that flags cadence and cutouts with comets
- Fixes the data types in the NPZ files to save memory. 